### PR TITLE
Fix Perplexity response block aggregation

### DIFF
--- a/polychat/model/client/perplexity_response.py
+++ b/polychat/model/client/perplexity_response.py
@@ -48,14 +48,23 @@ class PerplexityResponse(BaseModel):
         if not self.blocks:
             return None
 
+        answers: List[str] = []
+
         for block in self.blocks:
             intended_usage = block.get("intended_usage", "")
             if intended_usage == "ask_text" or str(intended_usage).startswith("ask_text"):
                 markdown_block = block.get("markdown_block")
                 if markdown_block:
-                    return markdown_block.get("answer")
+                    answer = markdown_block.get("answer")
+                    if answer:
+                        normalized_answer = answer.strip()
+                        if normalized_answer:
+                            answers.append(normalized_answer)
 
-        return None
+        if not answers:
+            return None
+
+        return "\n\n".join(answers)
 
     @computed_field
     @property

--- a/tests/unit/model/client/test_perplexity_response.py
+++ b/tests/unit/model/client/test_perplexity_response.py
@@ -1,0 +1,56 @@
+from polychat.model.client.perplexity_response import PerplexityResponse
+
+
+def test_answer_combines_all_markdown_blocks_in_order():
+    response = PerplexityResponse(
+        blocks=[
+            {
+                "intended_usage": "plan",
+                "plan_block": {"progress": "DONE"},
+            },
+            {
+                "intended_usage": "ask_text_0_markdown",
+                "markdown_block": {"answer": "Primo paragrafo."},
+            },
+            {
+                "intended_usage": "ask_text_1_markdown",
+                "markdown_block": {"answer": "## Seconda sezione"},
+            },
+            {
+                "intended_usage": "ask_text_2_markdown",
+                "markdown_block": {"answer": "Terza riga"},
+            },
+        ]
+    )
+
+    assert response.answer == "Primo paragrafo.\n\n## Seconda sezione\n\nTerza riga"
+
+
+def test_answer_returns_none_when_no_text_blocks_are_present():
+    response = PerplexityResponse(
+        blocks=[
+            {
+                "intended_usage": "plan",
+                "plan_block": {"progress": "DONE"},
+            }
+        ]
+    )
+
+    assert response.answer is None
+
+
+def test_answer_ignores_empty_text_blocks():
+    response = PerplexityResponse(
+        blocks=[
+            {
+                "intended_usage": "ask_text_0_markdown",
+                "markdown_block": {"answer": "  "},
+            },
+            {
+                "intended_usage": "ask_text_1_markdown",
+                "markdown_block": {"answer": "Contenuto finale"},
+            },
+        ]
+    )
+
+    assert response.answer == "Contenuto finale"


### PR DESCRIPTION
## Summary
- aggregate all `ask_text*` markdown blocks from the Perplexity thread payload instead of returning only the first one
- ignore empty markdown answers while preserving block order with paragraph separators
- add focused unit coverage for multi-block, empty-block and no-text-block cases

## Validation
- `pytest tests/unit/model/client/test_perplexity_response.py`
- `pytest tests/unit/client/test_perplexity_client.py tests/unit/service/test_chat_service.py tests/integration/test_perplexity_routes.py`

Closes #7
