### PR TITLE
Add provider login bootstrap endpoints

### DIFF
--- a/polychat/client/abstract_client.py
+++ b/polychat/client/abstract_client.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import datetime
+import json
 import logging
 import os
 import shutil
@@ -141,6 +142,25 @@ class AbstractClient:
     def _clear_session_dir(path: str) -> None:
         if os.path.exists(path):
             shutil.rmtree(path)
+
+    @staticmethod
+    def _write_text_file(path: str, content: str) -> None:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as file:
+            file.write(content)
+
+    @staticmethod
+    def _read_text_file(path: str) -> str:
+        with open(path, "r", encoding="utf-8") as file:
+            return file.read().strip()
+
+    @classmethod
+    def _write_json_file(cls, path: str, content: dict) -> None:
+        cls._write_text_file(path, json.dumps(content, ensure_ascii=True))
+
+    @classmethod
+    def _read_json_file(cls, path: str) -> dict:
+        return json.loads(cls._read_text_file(path))
 
     def _fetch_page_content(self, url: str, headers: Optional[dict] = None, timeout: int = 15) -> str:
         with requests.Session() as session:

--- a/polychat/client/auth_payload_parser.py
+++ b/polychat/client/auth_payload_parser.py
@@ -1,0 +1,144 @@
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class ParsedAuthPayload:
+    cookies: list[dict[str, Any]]
+    raw_json_value: Any | None = None
+    raw_text: str = ""
+
+
+class AuthPayloadParser:
+    @classmethod
+    def parse(cls, content: str) -> ParsedAuthPayload:
+        raw_content = (content or "").strip()
+        if not raw_content:
+            raise ValueError("Login payload mancante o vuoto")
+
+        if cls._looks_like_json(raw_content):
+            return cls._parse_json_payload(raw_content)
+
+        if cls._looks_like_netscape(raw_content):
+            return ParsedAuthPayload(cookies=cls._parse_netscape_payload(raw_content), raw_text=raw_content)
+
+        return ParsedAuthPayload(cookies=[], raw_text=raw_content)
+
+    @staticmethod
+    def _looks_like_json(content: str) -> bool:
+        return content.startswith("{") or content.startswith("[") or content.startswith('"')
+
+    @staticmethod
+    def _looks_like_netscape(content: str) -> bool:
+        lines = [line.strip() for line in content.splitlines() if line.strip()]
+        if not lines:
+            return False
+        if lines[0].startswith("# Netscape HTTP Cookie File"):
+            return True
+        return any(line.count("\t") >= 6 for line in lines if not line.startswith("#"))
+
+    @classmethod
+    def _parse_json_payload(cls, content: str) -> ParsedAuthPayload:
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Login payload JSON non valido") from exc
+
+        if isinstance(parsed, list):
+            return ParsedAuthPayload(
+                cookies=[cls._normalize_cookie(cookie) for cookie in parsed],
+                raw_json_value=parsed,
+                raw_text=content,
+            )
+
+        if cls._is_cookie_mapping(parsed):
+            return ParsedAuthPayload(
+                cookies=[cls._normalize_cookie(parsed)],
+                raw_json_value=parsed,
+                raw_text=content,
+            )
+
+        return ParsedAuthPayload(cookies=[], raw_json_value=parsed, raw_text=content)
+
+    @staticmethod
+    def _is_cookie_mapping(value: Any) -> bool:
+        return isinstance(value, dict) and "name" in value and "value" in value
+
+    @classmethod
+    def _normalize_cookie(cls, cookie: Any) -> dict[str, Any]:
+        if not isinstance(cookie, dict):
+            raise ValueError("Cookie JSON non valido: atteso oggetto")
+
+        name = str(cookie.get("name", "")).strip()
+        value = str(cookie.get("value", ""))
+        if not name:
+            raise ValueError("Cookie JSON non valido: campo 'name' mancante")
+
+        normalized: dict[str, Any] = {
+            "name": name,
+            "value": value,
+            "domain": str(cookie.get("domain", "")).strip(),
+            "path": str(cookie.get("path", "/") or "/"),
+        }
+
+        secure = cookie.get("secure")
+        if isinstance(secure, bool):
+            normalized["secure"] = secure
+
+        http_only = cookie.get("httpOnly")
+        if isinstance(http_only, bool):
+            normalized["httpOnly"] = http_only
+
+        same_site = cls._normalize_same_site(cookie.get("sameSite"))
+        if same_site:
+            normalized["sameSite"] = same_site
+
+        expires = cookie.get("expirationDate", cookie.get("expires"))
+        if expires not in (None, "", 0, "0"):
+            normalized["expires"] = int(float(expires))
+
+        return normalized
+
+    @classmethod
+    def _parse_netscape_payload(cls, content: str) -> list[dict[str, Any]]:
+        cookies: list[dict[str, Any]] = []
+        for raw_line in content.splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            parts = raw_line.split("\t")
+            if len(parts) != 7:
+                raise ValueError("Formato Netscape cookie non valido")
+
+            domain, _include_subdomains, path, secure, expires, name, value = parts
+            cookie: dict[str, Any] = {
+                "name": name.strip(),
+                "value": value.strip(),
+                "domain": domain.strip(),
+                "path": path.strip() or "/",
+                "secure": secure.strip().upper() == "TRUE",
+            }
+            if expires.strip() not in {"", "0"}:
+                cookie["expires"] = int(expires.strip())
+            cookies.append(cookie)
+
+        if not cookies:
+            raise ValueError("Nessun cookie trovato nel payload Netscape")
+
+        return cookies
+
+    @staticmethod
+    def _normalize_same_site(value: Any) -> str | None:
+        if value is None:
+            return None
+
+        normalized = str(value).strip().lower()
+        if normalized in {"none", "no_restriction"}:
+            return "None"
+        if normalized == "lax":
+            return "Lax"
+        if normalized == "strict":
+            return "Strict"
+        return None

--- a/polychat/client/chat_gpt_client.py
+++ b/polychat/client/chat_gpt_client.py
@@ -11,6 +11,7 @@ from camoufox.async_api import AsyncCamoufox
 from injector import inject
 
 from polychat.client.abstract_client import AbstractClient
+from polychat.client.auth_payload_parser import AuthPayloadParser
 from polychat.model.client.chatgpt_ask_result import ChatGptAskResult
 from polychat.model.client.chatgpt_conversation_detail import ConversationDetail
 from polychat.model.client.chatgpt_conversation_list import ConversationList
@@ -46,10 +47,27 @@ class ChatGptClient(AbstractClient):
         super().__init__()
         self.session_dir = os.path.join(session_dir, "chatgpt")
         self.storage_state_path = os.path.join(self.session_dir, "chatgpt_state.json")
+        self.cookie_path = os.path.join(self.session_dir, "chatgpt_cookie.txt")
         self.headless = headless
         self.session_cookie = session_cookie
         self.workspace_name = (workspace_name or "").strip()
         os.makedirs(self.session_dir, exist_ok=True)
+
+    async def login(self, content: str) -> None:
+        session_cookie = self._resolve_session_cookie_from_login_content(content)
+        self._write_text_file(self.cookie_path, session_cookie)
+
+        constraints = Screen(max_width=1920, max_height=1080)
+        async with AsyncCamoufox(headless=self.headless, humanize=True, screen=constraints) as browser:
+            context = await browser.new_context()
+            await context.add_cookies([self._build_session_cookie(session_cookie)])
+            page = await context.new_page()
+            self._attach_page_request_logger(page)
+            await self._goto(page, "https://chatgpt.com/", wait_until="domcontentloaded", timeout=20_000)
+            await page.wait_for_timeout(1_500)
+            await context.storage_state(path=self.storage_state_path)
+            await page.close()
+            await context.close()
 
     def logout(self) -> None:
         """Rimuove la cartella sessione ChatGPT."""
@@ -70,17 +88,7 @@ class ChatGptClient(AbstractClient):
                     context_options["storage_state"] = self.storage_state_path
                 context = await browser.new_context(**context_options)
                 if session_cookie:
-                    await context.add_cookies([
-                        {
-                            "name": "__Secure-next-auth.session-token",
-                            "value": session_cookie,
-                            "domain": "chatgpt.com",
-                            "path": "/",
-                            "httpOnly": True,
-                            "secure": True,
-                            "sameSite": "None",
-                        }
-                    ])
+                    await context.add_cookies([self._build_session_cookie(session_cookie)])
 
                 page = await context.new_page()
                 self._attach_page_request_logger(page)
@@ -158,17 +166,7 @@ class ChatGptClient(AbstractClient):
                 if os.path.exists(self.storage_state_path):
                     context_options["storage_state"] = self.storage_state_path
                 context = await browser.new_context(**context_options)
-                await context.add_cookies([
-                    {
-                        "name": "__Secure-next-auth.session-token",
-                        "value": session_cookie,
-                        "domain": "chatgpt.com",
-                        "path": "/",
-                        "httpOnly": True,
-                        "secure": True,
-                        "sameSite": "None",
-                    }
-                ])
+                await context.add_cookies([self._build_session_cookie(session_cookie)])
                 page = await context.new_page()
                 self._attach_page_request_logger(page)
 
@@ -269,17 +267,7 @@ class ChatGptClient(AbstractClient):
             if os.path.exists(self.storage_state_path):
                 context_options["storage_state"] = self.storage_state_path
             context = await browser.new_context(**context_options)
-            await context.add_cookies([
-                {
-                    "name": "__Secure-next-auth.session-token",
-                    "value": session_cookie,
-                    "domain": "chatgpt.com",
-                    "path": "/",
-                    "httpOnly": True,
-                    "secure": True,
-                    "sameSite": "None",
-                }
-            ])
+            await context.add_cookies([self._build_session_cookie(session_cookie)])
             page = await context.new_page()
             self._attach_page_request_logger(page)
 
@@ -303,10 +291,38 @@ class ChatGptClient(AbstractClient):
     def _load_session_cookie(self) -> str:
         """Carica il cookie di sessione da variabile ambiente."""
         cookie_value = (self.session_cookie or "").strip()
-        if not cookie_value:
-            raise ValueError("CHATGPT_SESSION_COOKIE mancante o vuoto")
+        if cookie_value:
+            return cookie_value
 
+        if os.path.exists(self.cookie_path):
+            cookie_value = self._read_text_file(self.cookie_path)
+            if cookie_value:
+                return cookie_value
+
+        raise ValueError("CHATGPT_SESSION_COOKIE mancante o vuoto")
+
+    def _resolve_session_cookie_from_login_content(self, content: str) -> str:
+        parsed = AuthPayloadParser.parse(content)
+        for cookie in parsed.cookies:
+            if cookie.get("name") == "__Secure-next-auth.session-token":
+                return str(cookie["value"])
+
+        cookie_value = parsed.raw_text.strip()
+        if not cookie_value:
+            raise ValueError("Cookie ChatGPT '__Secure-next-auth.session-token' mancante")
         return cookie_value
+
+    @staticmethod
+    def _build_session_cookie(session_cookie: str) -> dict:
+        return {
+            "name": "__Secure-next-auth.session-token",
+            "value": session_cookie,
+            "domain": "chatgpt.com",
+            "path": "/",
+            "httpOnly": True,
+            "secure": True,
+            "sameSite": "None",
+        }
 
     async def _select_workspace_by_name(self, page, workspace_name: str) -> None:
         target_name = " ".join(workspace_name.strip().lower().split())
@@ -464,17 +480,7 @@ class ChatGptClient(AbstractClient):
             if os.path.exists(self.storage_state_path):
                 context_options["storage_state"] = self.storage_state_path
             context = await browser.new_context(**context_options)
-            await context.add_cookies([
-                {
-                    "name": "__Secure-next-auth.session-token",
-                    "value": session_cookie,
-                    "domain": "chatgpt.com",
-                    "path": "/",
-                    "httpOnly": True,
-                    "secure": True,
-                    "sameSite": "None",
-                }
-            ])
+            await context.add_cookies([self._build_session_cookie(session_cookie)])
             page = await context.new_page()
             self._attach_page_request_logger(page)
             conversation_payload = await self._fetch_conversation_via_page(page, chat_id)

--- a/polychat/client/deepseek_client.py
+++ b/polychat/client/deepseek_client.py
@@ -9,6 +9,7 @@ from camoufox.async_api import AsyncCamoufox
 from injector import inject
 
 from polychat.client.abstract_client import AbstractClient
+from polychat.client.auth_payload_parser import AuthPayloadParser
 from polychat.model.client.deepseek_response import DeepseekResponse
 
 
@@ -34,9 +35,27 @@ class DeepseekClient(AbstractClient):
         super().__init__()
         self.session_dir = os.path.join(session_dir, "deepseek")
         self.storage_state_path = os.path.join(self.session_dir, "deepseek_state.json")
+        self.user_token_path = os.path.join(self.session_dir, "deepseek_user_token.json")
         self.headless = headless
         self.user_token_json = user_token_json
         os.makedirs(self.session_dir, exist_ok=True)
+
+    async def login(self, content: str) -> None:
+        token_json = self._resolve_user_token_json_from_login_content(content)
+        self._write_text_file(self.user_token_path, token_json)
+
+        constraints = Screen(max_width=1920, max_height=1080)
+        async with AsyncCamoufox(headless=self.headless, humanize=True, screen=constraints) as browser:
+            context = await browser.new_context()
+            page = await context.new_page()
+            self._attach_page_request_logger(page)
+            await self._goto(page, self.BASE_URL, wait_until="domcontentloaded", timeout=20_000)
+            await self._set_user_token(page, token_json)
+            await page.reload(wait_until="domcontentloaded", timeout=20_000)
+            await page.wait_for_timeout(1_500)
+            await context.storage_state(path=self.storage_state_path)
+            await page.close()
+            await context.close()
 
     async def ask(self, message: str, chat_id: Optional[str] = None, type_input: bool = True) -> DeepseekResponse:
         token_json = self._load_user_token_json()
@@ -361,9 +380,24 @@ class DeepseekClient(AbstractClient):
 
     def _load_user_token_json(self) -> str:
         token_json = (self.user_token_json or "").strip()
-        if not token_json:
-            raise ValueError("DEEPSEEK_USER_TOKEN_JSON mancante o vuoto")
-        return self._validate_user_token_json(token_json)
+        if token_json:
+            return self._validate_user_token_json(token_json)
+        if os.path.exists(self.user_token_path):
+            token_json = self._read_text_file(self.user_token_path)
+            if token_json:
+                return self._validate_user_token_json(token_json)
+        raise ValueError("DEEPSEEK_USER_TOKEN_JSON mancante o vuoto")
+
+    def _resolve_user_token_json_from_login_content(self, content: str) -> str:
+        parsed = AuthPayloadParser.parse(content)
+        if parsed.raw_json_value is not None:
+            return self._validate_user_token_json(json.dumps(parsed.raw_json_value, ensure_ascii=False))
+
+        for cookie in parsed.cookies:
+            if cookie.get("name") == "userToken":
+                return self._validate_user_token_json(str(cookie.get("value", "")))
+
+        return self._validate_user_token_json(parsed.raw_text.strip())
 
     async def _set_user_token(self, page, token_json: str) -> None:
         await page.evaluate(

--- a/polychat/client/gemini_client.py
+++ b/polychat/client/gemini_client.py
@@ -9,6 +9,7 @@ from camoufox.async_api import AsyncCamoufox
 from injector import inject
 
 from polychat.client.abstract_client import AbstractClient
+from polychat.client.auth_payload_parser import AuthPayloadParser
 from polychat.model.client.gemini_response import GeminiResponse
 
 
@@ -32,10 +33,33 @@ class GeminiClient(AbstractClient):
         super().__init__()
         self.session_dir = os.path.join(session_dir, "gemini")
         self.storage_state_path = os.path.join(self.session_dir, "gemini_state.json")
+        self.cookies_path = os.path.join(self.session_dir, "gemini_cookies.json")
         self.headless = headless
         self.cookie_1psid = cookie_1psid
         self.cookie_1psidts = cookie_1psidts
         os.makedirs(self.session_dir, exist_ok=True)
+
+    async def login(self, content: str) -> None:
+        cookie_1psid, cookie_1psidts = self._resolve_session_cookies_from_login_content(content)
+        self._write_json_file(
+            self.cookies_path,
+            {
+                "__Secure-1PSID": cookie_1psid,
+                "__Secure-1PSIDTS": cookie_1psidts,
+            },
+        )
+
+        constraints = Screen(max_width=1920, max_height=1080)
+        async with AsyncCamoufox(headless=self.headless, humanize=True, screen=constraints) as browser:
+            context = await browser.new_context()
+            await context.add_cookies(self._build_session_cookies(cookie_1psid, cookie_1psidts))
+            page = await context.new_page()
+            self._attach_page_request_logger(page)
+            await self._goto(page, self.BASE_URL, wait_until="domcontentloaded", timeout=20_000)
+            await page.wait_for_timeout(1_500)
+            await context.storage_state(path=self.storage_state_path)
+            await page.close()
+            await context.close()
 
     async def ask(self, message: str, chat_id: Optional[str] = None, type_input: bool = True) -> GeminiResponse:
         cookie_1psid, cookie_1psidts = self._load_session_cookies()
@@ -48,26 +72,7 @@ class GeminiClient(AbstractClient):
                     context_options["storage_state"] = self.storage_state_path
 
                 context = await browser.new_context(**context_options)
-                await context.add_cookies([
-                    {
-                        "name": "__Secure-1PSID",
-                        "value": cookie_1psid,
-                        "domain": ".google.com",
-                        "path": "/",
-                        "httpOnly": True,
-                        "secure": True,
-                        "sameSite": "None",
-                    },
-                    {
-                        "name": "__Secure-1PSIDTS",
-                        "value": cookie_1psidts,
-                        "domain": ".google.com",
-                        "path": "/",
-                        "httpOnly": True,
-                        "secure": True,
-                        "sameSite": "None",
-                    },
-                ])
+                await context.add_cookies(self._build_session_cookies(cookie_1psid, cookie_1psidts))
 
                 page = await context.new_page()
                 self._attach_page_request_logger(page)
@@ -120,26 +125,7 @@ class GeminiClient(AbstractClient):
                 context_options["storage_state"] = self.storage_state_path
 
             context = await browser.new_context(**context_options)
-            await context.add_cookies([
-                {
-                    "name": "__Secure-1PSID",
-                    "value": cookie_1psid,
-                    "domain": ".google.com",
-                    "path": "/",
-                    "httpOnly": True,
-                    "secure": True,
-                    "sameSite": "None",
-                },
-                {
-                    "name": "__Secure-1PSIDTS",
-                    "value": cookie_1psidts,
-                    "domain": ".google.com",
-                    "path": "/",
-                    "httpOnly": True,
-                    "secure": True,
-                    "sameSite": "None",
-                },
-            ])
+            await context.add_cookies(self._build_session_cookies(cookie_1psid, cookie_1psidts))
 
             page = await context.new_page()
             self._attach_page_request_logger(page)
@@ -262,26 +248,7 @@ class GeminiClient(AbstractClient):
                 context_options["storage_state"] = self.storage_state_path
 
             context = await browser.new_context(**context_options)
-            await context.add_cookies([
-                {
-                    "name": "__Secure-1PSID",
-                    "value": cookie_1psid,
-                    "domain": ".google.com",
-                    "path": "/",
-                    "httpOnly": True,
-                    "secure": True,
-                    "sameSite": "None",
-                },
-                {
-                    "name": "__Secure-1PSIDTS",
-                    "value": cookie_1psidts,
-                    "domain": ".google.com",
-                    "path": "/",
-                    "httpOnly": True,
-                    "secure": True,
-                    "sameSite": "None",
-                },
-            ])
+            await context.add_cookies(self._build_session_cookies(cookie_1psid, cookie_1psidts))
 
             page = await context.new_page()
             self._attach_page_request_logger(page)
@@ -318,26 +285,7 @@ class GeminiClient(AbstractClient):
                 if os.path.exists(self.storage_state_path):
                     context_options["storage_state"] = self.storage_state_path
                 context = await browser.new_context(**context_options)
-                await context.add_cookies([
-                    {
-                        "name": "__Secure-1PSID",
-                        "value": cookie_1psid,
-                        "domain": ".google.com",
-                        "path": "/",
-                        "httpOnly": True,
-                        "secure": True,
-                        "sameSite": "None",
-                    },
-                    {
-                        "name": "__Secure-1PSIDTS",
-                        "value": cookie_1psidts,
-                        "domain": ".google.com",
-                        "path": "/",
-                        "httpOnly": True,
-                        "secure": True,
-                        "sameSite": "None",
-                    },
-                ])
+                await context.add_cookies(self._build_session_cookies(cookie_1psid, cookie_1psidts))
                 page = await context.new_page()
                 self._attach_page_request_logger(page)
                 await self._goto(page, self.BASE_URL, wait_until="domcontentloaded", timeout=20_000)
@@ -368,8 +316,53 @@ class GeminiClient(AbstractClient):
     def _load_session_cookies(self) -> tuple[str, str]:
         cookie_1psid = (self.cookie_1psid or "").strip()
         cookie_1psidts = (self.cookie_1psidts or "").strip()
+        if cookie_1psid and cookie_1psidts:
+            return cookie_1psid, cookie_1psidts
+
+        if os.path.exists(self.cookies_path):
+            persisted = self._read_json_file(self.cookies_path)
+            cookie_1psid = str(persisted.get("__Secure-1PSID", "")).strip()
+            cookie_1psidts = str(persisted.get("__Secure-1PSIDTS", "")).strip()
+            if cookie_1psid and cookie_1psidts:
+                return cookie_1psid, cookie_1psidts
+
+        raise ValueError("GEMINI_COOKIE_1PSID e GEMINI_COOKIE_1PSIDTS sono obbligatori")
+
+    def _resolve_session_cookies_from_login_content(self, content: str) -> tuple[str, str]:
+        parsed = AuthPayloadParser.parse(content)
+        values = {
+            cookie.get("name"): str(cookie.get("value", ""))
+            for cookie in parsed.cookies
+            if cookie.get("name") in {"__Secure-1PSID", "__Secure-1PSIDTS"}
+        }
+        cookie_1psid = values.get("__Secure-1PSID", "").strip()
+        cookie_1psidts = values.get("__Secure-1PSIDTS", "").strip()
         if not cookie_1psid or not cookie_1psidts:
-            raise ValueError("GEMINI_COOKIE_1PSID e GEMINI_COOKIE_1PSIDTS sono obbligatori")
+            raise ValueError("Payload Gemini incompleto: servono __Secure-1PSID e __Secure-1PSIDTS")
+        return cookie_1psid, cookie_1psidts
+
+    @staticmethod
+    def _build_session_cookies(cookie_1psid: str, cookie_1psidts: str) -> list[dict]:
+        return [
+            {
+                "name": "__Secure-1PSID",
+                "value": cookie_1psid,
+                "domain": ".google.com",
+                "path": "/",
+                "httpOnly": True,
+                "secure": True,
+                "sameSite": "None",
+            },
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": cookie_1psidts,
+                "domain": ".google.com",
+                "path": "/",
+                "httpOnly": True,
+                "secure": True,
+                "sameSite": "None",
+            },
+        ]
         return cookie_1psid, cookie_1psidts
 
     @staticmethod

--- a/polychat/client/kimi_client.py
+++ b/polychat/client/kimi_client.py
@@ -8,6 +8,7 @@ from camoufox.async_api import AsyncCamoufox
 from injector import inject
 
 from polychat.client.abstract_client import AbstractClient
+from polychat.client.auth_payload_parser import AuthPayloadParser
 from polychat.model.client.kimi_response import KimiResponse
 
 
@@ -28,15 +29,17 @@ class KimiClient(AbstractClient):
         super().__init__()
         self.session_dir = os.path.join(session_dir, "kimi")
         self.storage_state_path = os.path.join(self.session_dir, "kimi_state.json")
+        self.auth_token_path = os.path.join(self.session_dir, "kimi_auth_token.txt")
         self.headless = headless
         self.auth_token = auth_token
         os.makedirs(self.session_dir, exist_ok=True)
 
-    async def login(self) -> None:
+    async def login(self, content: str) -> None:
         """Inietta il cookie di auth Kimi e salva lo stato della sessione."""
         os.makedirs(self.session_dir, exist_ok=True)
         constraints = Screen(max_width=1920, max_height=1080)
-        auth_token = self._load_auth_token()
+        auth_token = self._resolve_auth_token_from_login_content(content)
+        self._write_text_file(self.auth_token_path, auth_token)
         async with AsyncCamoufox(headless=self.headless, humanize=True, screen=constraints) as browser:
             context = await browser.new_context()
             await context.add_cookies([self._build_auth_cookie(auth_token)])
@@ -239,8 +242,22 @@ class KimiClient(AbstractClient):
 
     def _load_auth_token(self) -> str:
         auth_token = (self.auth_token or "").strip()
+        if auth_token:
+            return auth_token
+        if os.path.exists(self.auth_token_path):
+            auth_token = self._read_text_file(self.auth_token_path)
+            if auth_token:
+                return auth_token
+        raise ValueError("KIMI_AUTH_TOKEN mancante o vuoto")
+
+    def _resolve_auth_token_from_login_content(self, content: str) -> str:
+        parsed = AuthPayloadParser.parse(content)
+        for cookie in parsed.cookies:
+            if cookie.get("name") == "kimi-auth":
+                return str(cookie["value"])
+        auth_token = parsed.raw_text.strip()
         if not auth_token:
-            raise ValueError("KIMI_AUTH_TOKEN mancante o vuoto")
+            raise ValueError("Cookie Kimi 'kimi-auth' mancante")
         return auth_token
 
     @staticmethod

--- a/polychat/client/perplexity_client.py
+++ b/polychat/client/perplexity_client.py
@@ -6,6 +6,7 @@ from injector import inject
 from browserforge.fingerprints import Screen
 
 from polychat.client.abstract_client import AbstractClient
+from polychat.client.auth_payload_parser import AuthPayloadParser
 from polychat.model.client.perplexity_response import PerplexityResponse
 
 
@@ -31,15 +32,21 @@ class PerplexityClient(AbstractClient):
         self.base_url = "https://www.perplexity.ai/"
         os.makedirs(self.session_dir, exist_ok=True)
 
-    async def login(self, session_cookie: str) -> None:
-        """Salva il cookie di sessione fornito manualmente."""
-        cookie_value = (session_cookie or "").strip()
-        if not cookie_value:
-            raise ValueError("Cookie di sessione mancante")
+    async def login(self, content: str) -> None:
+        cookie_value = self._resolve_session_cookie_from_login_content(content)
+        self._write_text_file(self.cookie_path, cookie_value)
 
-        os.makedirs(self.session_dir, exist_ok=True)
-        with open(self.cookie_path, "w", encoding="utf-8") as f:
-            f.write(cookie_value)
+        constraints = Screen(max_width=1920, max_height=1080)
+        async with AsyncCamoufox(headless=self.headless, humanize=True, screen=constraints) as browser:
+            context = await browser.new_context()
+            await context.add_cookies([self._build_session_cookie(cookie_value)])
+            page = await context.new_page()
+            self._attach_page_request_logger(page)
+            await self._goto(page, self.base_url, wait_until="domcontentloaded", timeout=20_000)
+            await page.wait_for_timeout(1_500)
+            await context.storage_state(path=self.storage_state_path)
+            await page.close()
+            await context.close()
 
     async def ask(self, message: str, chat_id: Optional[str] = None, type_input: bool = True) -> PerplexityResponse:
         """
@@ -66,17 +73,7 @@ class PerplexityClient(AbstractClient):
                     context_options["storage_state"] = self.storage_state_path
 
                 context = await browser.new_context(**context_options)
-                await context.add_cookies([
-                    {
-                        "name": "__Secure-next-auth.session-token",
-                        "value": session_cookie,
-                        "domain": ".perplexity.ai",
-                        "path": "/",
-                        "httpOnly": True,
-                        "secure": True,
-                        "sameSite": "None",
-                    }
-                ])
+                await context.add_cookies([self._build_session_cookie(session_cookie)])
                 page = await context.new_page()
                 self._attach_page_request_logger(page)
 
@@ -133,17 +130,7 @@ class PerplexityClient(AbstractClient):
                 context_options["storage_state"] = self.storage_state_path
 
             context = await browser.new_context(**context_options)
-            await context.add_cookies([
-                {
-                    "name": "__Secure-next-auth.session-token",
-                    "value": session_cookie,
-                    "domain": ".perplexity.ai",
-                    "path": "/",
-                    "httpOnly": True,
-                    "secure": True,
-                    "sameSite": "None",
-                }
-            ])
+            await context.add_cookies([self._build_session_cookie(session_cookie)])
             page = await context.new_page()
             self._attach_page_request_logger(page)
 
@@ -183,17 +170,7 @@ class PerplexityClient(AbstractClient):
                 if os.path.exists(self.storage_state_path):
                     context_options["storage_state"] = self.storage_state_path
                 context = await browser.new_context(**context_options)
-                await context.add_cookies([
-                    {
-                        "name": "__Secure-next-auth.session-token",
-                        "value": session_cookie,
-                        "domain": ".perplexity.ai",
-                        "path": "/",
-                        "httpOnly": True,
-                        "secure": True,
-                        "sameSite": "None",
-                    }
-                ])
+                await context.add_cookies([self._build_session_cookie(session_cookie)])
                 page = await context.new_page()
                 self._attach_page_request_logger(page)
                 session_detection_task = asyncio.create_task(
@@ -253,17 +230,7 @@ class PerplexityClient(AbstractClient):
                 context_options["storage_state"] = self.storage_state_path
 
             context = await browser.new_context(**context_options)
-            await context.add_cookies([
-                {
-                    "name": "__Secure-next-auth.session-token",
-                    "value": session_cookie,
-                    "domain": ".perplexity.ai",
-                    "path": "/",
-                    "httpOnly": True,
-                    "secure": True,
-                    "sameSite": "None",
-                }
-            ])
+            await context.add_cookies([self._build_session_cookie(session_cookie)])
             page = await context.new_page()
             self._attach_page_request_logger(page)
             response_content = await self._wait_for_thread_response(page, chat_id, post_navigation_wait_ms=10_000)
@@ -349,12 +316,38 @@ class PerplexityClient(AbstractClient):
             return cookie_value
 
         if os.path.exists(self.cookie_path):
-            with open(self.cookie_path, "r", encoding="utf-8") as f:
-                cookie_value = f.read().strip()
+            cookie_value = self._read_text_file(self.cookie_path)
             if cookie_value:
                 return cookie_value
 
         raise ValueError("PERPLEXITY_SESSION_COOKIE mancante o vuoto")
+
+    def _resolve_session_cookie_from_login_content(self, content: str) -> str:
+        parsed = AuthPayloadParser.parse(content)
+        cookie = self._find_cookie(parsed.cookies, "__Secure-next-auth.session-token")
+        cookie_value = cookie["value"] if cookie else parsed.raw_text.strip()
+        if not cookie_value:
+            raise ValueError("Cookie Perplexity '__Secure-next-auth.session-token' mancante")
+        return cookie_value
+
+    @staticmethod
+    def _find_cookie(cookies: list[dict[str, Any]], name: str) -> Optional[dict[str, Any]]:
+        for cookie in cookies:
+            if cookie.get("name") == name:
+                return cookie
+        return None
+
+    @staticmethod
+    def _build_session_cookie(session_cookie: str) -> dict[str, Any]:
+        return {
+            "name": "__Secure-next-auth.session-token",
+            "value": session_cookie,
+            "domain": ".perplexity.ai",
+            "path": "/",
+            "httpOnly": True,
+            "secure": True,
+            "sameSite": "None",
+        }
 
     @classmethod
     def _extract_slug_from_url(cls, current_url: str) -> str:

--- a/polychat/client/qwen_client.py
+++ b/polychat/client/qwen_client.py
@@ -9,6 +9,7 @@ from camoufox.async_api import AsyncCamoufox
 from injector import inject
 
 from polychat.client.abstract_client import AbstractClient
+from polychat.client.auth_payload_parser import AuthPayloadParser
 from polychat.model.client.qwen_response import QwenResponse
 
 
@@ -34,9 +35,26 @@ class QwenClient(AbstractClient):
         super().__init__()
         self.session_dir = os.path.join(session_dir, "qwen")
         self.storage_state_path = os.path.join(self.session_dir, "qwen_state.json")
+        self.cookie_path = os.path.join(self.session_dir, "qwen_cookie.txt")
         self.headless = headless
         self.session_cookie = session_cookie
         os.makedirs(self.session_dir, exist_ok=True)
+
+    async def login(self, content: str) -> None:
+        session_cookie = self._resolve_session_cookie_from_login_content(content)
+        self._write_text_file(self.cookie_path, session_cookie)
+
+        constraints = Screen(max_width=1920, max_height=1080)
+        async with AsyncCamoufox(headless=self.headless, humanize=True, screen=constraints) as browser:
+            context = await browser.new_context()
+            await context.add_cookies([self._build_session_cookie(session_cookie)])
+            page = await context.new_page()
+            self._attach_page_request_logger(page)
+            await self._goto(page, self.BASE_URL, wait_until="domcontentloaded", timeout=20_000)
+            await page.wait_for_timeout(1_500)
+            await context.storage_state(path=self.storage_state_path)
+            await page.close()
+            await context.close()
 
     async def ask(self, message: str, chat_id: Optional[str] = None, type_input: bool = True) -> QwenResponse:
         session_cookie = self._load_session_cookie()
@@ -54,18 +72,7 @@ class QwenClient(AbstractClient):
                     context_options["storage_state"] = self.storage_state_path
 
                 context = await browser.new_context(**context_options)
-                await context.add_cookies(
-                    [
-                        {
-                            "name": "token",
-                            "value": session_cookie,
-                            "domain": "chat.qwen.ai",
-                            "path": "/",
-                            "secure": True,
-                            "sameSite": "Lax",
-                        }
-                    ]
-                )
+                await context.add_cookies([self._build_session_cookie(session_cookie)])
 
                 page = await context.new_page()
                 self._attach_page_request_logger(page)
@@ -125,18 +132,7 @@ class QwenClient(AbstractClient):
                     context_options["storage_state"] = self.storage_state_path
 
                 context = await browser.new_context(**context_options)
-                await context.add_cookies(
-                    [
-                        {
-                            "name": "token",
-                            "value": session_cookie,
-                            "domain": "chat.qwen.ai",
-                            "path": "/",
-                            "secure": True,
-                            "sameSite": "Lax",
-                        }
-                    ]
-                )
+                await context.add_cookies([self._build_session_cookie(session_cookie)])
 
                 page = await context.new_page()
                 self._attach_page_request_logger(page)
@@ -193,18 +189,7 @@ class QwenClient(AbstractClient):
                 context_options["storage_state"] = self.storage_state_path
 
             context = await browser.new_context(**context_options)
-            await context.add_cookies(
-                [
-                    {
-                        "name": "token",
-                        "value": session_cookie,
-                        "domain": "chat.qwen.ai",
-                        "path": "/",
-                        "secure": True,
-                        "sameSite": "Lax",
-                    }
-                ]
-            )
+            await context.add_cookies([self._build_session_cookie(session_cookie)])
 
             page = await context.new_page()
             self._attach_page_request_logger(page)
@@ -312,9 +297,34 @@ class QwenClient(AbstractClient):
 
     def _load_session_cookie(self) -> str:
         cookie_value = (self.session_cookie or "").strip()
+        if cookie_value:
+            return cookie_value
+        if os.path.exists(self.cookie_path):
+            cookie_value = self._read_text_file(self.cookie_path)
+            if cookie_value:
+                return cookie_value
+        raise ValueError("QWEN_SESSION_COOKIE mancante o vuoto")
+
+    def _resolve_session_cookie_from_login_content(self, content: str) -> str:
+        parsed = AuthPayloadParser.parse(content)
+        for cookie in parsed.cookies:
+            if cookie.get("name") == "token":
+                return str(cookie["value"])
+        cookie_value = parsed.raw_text.strip()
         if not cookie_value:
-            raise ValueError("QWEN_SESSION_COOKIE mancante o vuoto")
+            raise ValueError("Cookie Qwen 'token' mancante")
         return cookie_value
+
+    @staticmethod
+    def _build_session_cookie(session_cookie: str) -> dict:
+        return {
+            "name": "token",
+            "value": session_cookie,
+            "domain": "chat.qwen.ai",
+            "path": "/",
+            "secure": True,
+            "sameSite": "Lax",
+        }
 
     async def _submit_prompt(
         self,

--- a/polychat/controller/chat_gpt_controller.py
+++ b/polychat/controller/chat_gpt_controller.py
@@ -6,6 +6,7 @@ from injector import inject
 
 from polychat.mapper.service.chat_to_api_mapper import ChatToApiMapper
 from polychat.model.chat_request import ChatRequest
+from polychat.model.api.login_request import LoginRequest
 from polychat.model.api.chat_response import (
     ChannelStatusResponse,
     ChatCompleteResponse,
@@ -39,6 +40,12 @@ class ChatGptController:
             methods=["POST"],
             summary="Invia un messaggio a ChatGPT e attende la risposta finale",
             response_model=ChatCompleteResponse,
+        )
+        self.router.add_api_route(
+            "/login",
+            self.login,
+            methods=["POST"],
+            summary="Login ChatGPT",
         )
         self.router.add_api_route(
             "/logout",
@@ -126,6 +133,16 @@ class ChatGptController:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Error fetching ChatGPT status: {exc}",
+            )
+
+    async def login(self, request: LoginRequest) -> dict:
+        try:
+            await self.chatgpt_service.login(request.content)
+            return {"status": "ok"}
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Error processing ChatGPT login: {exc}",
             )
 
     def proxy_download(self, download_url: str = Query(...)) -> StreamingResponse:

--- a/polychat/controller/deepseek_controller.py
+++ b/polychat/controller/deepseek_controller.py
@@ -8,6 +8,7 @@ from polychat.model.api.chat_response import (
     ChatMessageResponse,
     ChatStartResponse,
 )
+from polychat.model.api.login_request import LoginRequest
 from polychat.model.chat_request import ChatRequest
 from polychat.service.deepseek_service import DeepseekService
 
@@ -36,6 +37,12 @@ class DeepseekController:
             methods=["POST"],
             summary="Invia un messaggio a Deepseek e attende la risposta finale",
             response_model=ChatCompleteResponse,
+        )
+        self.router.add_api_route(
+            "/login",
+            self.login,
+            methods=["POST"],
+            summary="Login Deepseek",
         )
         self.router.add_api_route(
             "/logout",
@@ -113,4 +120,14 @@ class DeepseekController:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Error fetching Deepseek status: {exc}",
+            )
+
+    async def login(self, request: LoginRequest) -> dict:
+        try:
+            await self.deepseek_service.login(request.content)
+            return {"status": "ok"}
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Error processing Deepseek login: {exc}",
             )

--- a/polychat/controller/gemini_controller.py
+++ b/polychat/controller/gemini_controller.py
@@ -8,6 +8,7 @@ from polychat.model.api.chat_response import (
     ChatMessageResponse,
     ChatStartResponse,
 )
+from polychat.model.api.login_request import LoginRequest
 from polychat.model.chat_request import ChatRequest
 from polychat.service.gemini_service import GeminiService
 
@@ -36,6 +37,12 @@ class GeminiController:
             methods=["POST"],
             summary="Invia un messaggio a Gemini e attende la risposta finale",
             response_model=ChatCompleteResponse,
+        )
+        self.router.add_api_route(
+            "/login",
+            self.login,
+            methods=["POST"],
+            summary="Login Gemini",
         )
         self.router.add_api_route(
             "/logout",
@@ -113,4 +120,14 @@ class GeminiController:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Error fetching Gemini status: {exc}",
+            )
+
+    async def login(self, request: LoginRequest) -> dict:
+        try:
+            await self.gemini_service.login(request.content)
+            return {"status": "ok"}
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Error processing Gemini login: {exc}",
             )

--- a/polychat/controller/kimi_controller.py
+++ b/polychat/controller/kimi_controller.py
@@ -3,6 +3,7 @@ from injector import inject
 
 from polychat.mapper.service.chat_to_api_mapper import ChatToApiMapper
 from polychat.model.chat_request import ChatRequest
+from polychat.model.api.login_request import LoginRequest
 from polychat.model.api.chat_response import (
     ChannelStatusResponse,
     ChatCompleteResponse,
@@ -37,6 +38,12 @@ class KimiController:
             methods=["POST"],
             summary="Invia un messaggio a Kimi e attende la risposta finale",
             response_model=ChatCompleteResponse,
+        )
+        self.router.add_api_route(
+            "/login",
+            self.login,
+            methods=["POST"],
+            summary="Login Kimi",
         )
         self.router.add_api_route(
             "/logout",
@@ -107,4 +114,14 @@ class KimiController:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Error fetching Kimi status: {exc}",
+            )
+
+    async def login(self, request: LoginRequest) -> dict:
+        try:
+            await self.kimi_service.login(request.content)
+            return {"status": "ok"}
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Error processing Kimi login: {exc}",
             )

--- a/polychat/controller/perplexity_controller.py
+++ b/polychat/controller/perplexity_controller.py
@@ -3,6 +3,7 @@ from injector import inject
 
 from polychat.model.chat_request import ChatRequest
 from polychat.mapper.service.chat_to_api_mapper import ChatToApiMapper
+from polychat.model.api.login_request import LoginRequest
 from polychat.model.api.chat_response import (
     ChannelStatusResponse,
     ChatCompleteResponse,
@@ -37,6 +38,12 @@ class PerplexityController:
             methods=["POST"],
             summary="Send a message to Perplexity and wait for the completed response",
             response_model=ChatCompleteResponse,
+        )
+        self.router.add_api_route(
+            "/login",
+            self.login,
+            methods=["POST"],
+            summary="Login Perplexity",
         )
         self.router.add_api_route(
             "/logout",
@@ -117,4 +124,14 @@ class PerplexityController:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Error fetching Perplexity status: {exc}",
+            )
+
+    async def login(self, request: LoginRequest) -> dict:
+        try:
+            await self.perplexity_service.login(request.content)
+            return {"status": "ok"}
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Error processing Perplexity login: {exc}",
             )

--- a/polychat/controller/qwen_controller.py
+++ b/polychat/controller/qwen_controller.py
@@ -8,6 +8,7 @@ from polychat.model.api.chat_response import (
     ChatMessageResponse,
     ChatStartResponse,
 )
+from polychat.model.api.login_request import LoginRequest
 from polychat.model.chat_request import ChatRequest
 from polychat.service.qwen_service import QwenService
 
@@ -36,6 +37,12 @@ class QwenController:
             methods=["POST"],
             summary="Invia un messaggio a Qwen e attende la risposta finale",
             response_model=ChatCompleteResponse,
+        )
+        self.router.add_api_route(
+            "/login",
+            self.login,
+            methods=["POST"],
+            summary="Login Qwen",
         )
         self.router.add_api_route(
             "/logout",
@@ -113,4 +120,14 @@ class QwenController:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Error fetching Qwen status: {exc}",
+            )
+
+    async def login(self, request: LoginRequest) -> dict:
+        try:
+            await self.qwen_service.login(request.content)
+            return {"status": "ok"}
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Error processing Qwen login: {exc}",
             )

--- a/polychat/model/api/login_request.py
+++ b/polychat/model/api/login_request.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class LoginRequest(BaseModel):
+    content: str

--- a/polychat/service/chat_gpt_service.py
+++ b/polychat/service/chat_gpt_service.py
@@ -18,6 +18,9 @@ class ChatGptService:
         """Rimuove la sessione ChatGPT salvata."""
         self.chatgpt_client.logout()
 
+    async def login(self, content: str) -> None:
+        await self.chatgpt_client.login(content)
+
     async def status(self) -> dict:
         return await self.chatgpt_client.status()
 

--- a/polychat/service/deepseek_service.py
+++ b/polychat/service/deepseek_service.py
@@ -17,6 +17,9 @@ class DeepseekService:
     def logout(self) -> None:
         self.deepseek_client.logout()
 
+    async def login(self, content: str) -> None:
+        await self.deepseek_client.login(content)
+
     async def status(self) -> dict:
         return await self.deepseek_client.status()
 

--- a/polychat/service/gemini_service.py
+++ b/polychat/service/gemini_service.py
@@ -17,6 +17,9 @@ class GeminiService:
     def logout(self) -> None:
         self.gemini_client.logout()
 
+    async def login(self, content: str) -> None:
+        await self.gemini_client.login(content)
+
     async def status(self) -> dict:
         return await self.gemini_client.status()
 

--- a/polychat/service/kimi_service.py
+++ b/polychat/service/kimi_service.py
@@ -14,9 +14,9 @@ class KimiService:
         self.kimi_client = kimi_client
         self.kimi_chat_mapper = kimi_chat_mapper
 
-    async def login(self) -> None:
+    async def login(self, content: str) -> None:
         """Esegue il login a Kimi tramite il client."""
-        await self.kimi_client.login()
+        await self.kimi_client.login(content)
 
     def logout(self) -> None:
         self.kimi_client.logout()

--- a/polychat/service/qwen_service.py
+++ b/polychat/service/qwen_service.py
@@ -17,6 +17,9 @@ class QwenService:
     def logout(self) -> None:
         self.qwen_client.logout()
 
+    async def login(self, content: str) -> None:
+        await self.qwen_client.login(content)
+
     async def status(self) -> dict:
         return await self.qwen_client.status()
 

--- a/tests/integration/test_perplexity_routes.py
+++ b/tests/integration/test_perplexity_routes.py
@@ -8,6 +8,9 @@ from polychat.model.service.chat_metadata import ChatMetadata
 
 
 class _FakePerplexityService:
+    def __init__(self):
+        self.login_content = None
+
     async def ask(self, message: str, chat_id: str | None = None, type_input: bool = True) -> Chat:
         return Chat(id="chat-abc", message="", metadata=ChatMetadata(provider="perplexity"))
 
@@ -32,6 +35,9 @@ class _FakePerplexityService:
             "is_logged_in": False,
             "detail": "TODO",
         }
+
+    async def login(self, content: str) -> None:
+        self.login_content = content
 
 
 def create_test_app():
@@ -73,3 +79,13 @@ def test_post_perplexity_chat_complete_returns_full_payload():
         "message": "from fake",
         "image_url": "https://img.test/fake.png",
     }
+
+
+def test_post_perplexity_login_returns_ok():
+    app = create_test_app()
+    client = TestClient(app)
+
+    response = client.post("/perplexity/chats/login", json={"content": "cookie-123"})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/tests/unit/client/test_auth_payload_parser.py
+++ b/tests/unit/client/test_auth_payload_parser.py
@@ -1,0 +1,67 @@
+import pytest
+
+from polychat.client.auth_payload_parser import AuthPayloadParser
+
+
+def test_parse_json_cookie_export():
+    payload = """
+    [
+      {
+        "domain": ".chatgpt.com",
+        "expirationDate": 1778518853.821406,
+        "httpOnly": true,
+        "name": "__Secure-next-auth.session-token",
+        "path": "/",
+        "sameSite": "no_restriction",
+        "secure": true,
+        "value": "token-123"
+      }
+    ]
+    """
+
+    parsed = AuthPayloadParser.parse(payload)
+
+    assert parsed.cookies == [
+        {
+            "name": "__Secure-next-auth.session-token",
+            "value": "token-123",
+            "domain": ".chatgpt.com",
+            "path": "/",
+            "httpOnly": True,
+            "secure": True,
+            "sameSite": "None",
+            "expires": 1778518853,
+        }
+    ]
+
+
+def test_parse_netscape_cookie_export():
+    payload = """
+    # Netscape HTTP Cookie File
+    .chat.qwen.ai\tTRUE\t/\tTRUE\t1779826753\ttoken\tqwen-123
+    """
+
+    parsed = AuthPayloadParser.parse(payload)
+
+    assert parsed.cookies == [
+        {
+            "name": "token",
+            "value": "qwen-123",
+            "domain": ".chat.qwen.ai",
+            "path": "/",
+            "secure": True,
+            "expires": 1779826753,
+        }
+    ]
+
+
+def test_parse_raw_text_fallback():
+    parsed = AuthPayloadParser.parse("plain-token")
+
+    assert parsed.cookies == []
+    assert parsed.raw_text == "plain-token"
+
+
+def test_parse_invalid_json_raises():
+    with pytest.raises(ValueError, match="JSON non valido"):
+        AuthPayloadParser.parse('{"broken"')

--- a/tests/unit/client/test_chat_gpt_client.py
+++ b/tests/unit/client/test_chat_gpt_client.py
@@ -191,6 +191,23 @@ def test_get_conversations_raises_when_session_cookie_is_missing(tmp_path):
         client.get_conversations()
 
 
+def test_load_session_cookie_reads_persisted_file(tmp_path):
+    client = ChatGptClient(str(tmp_path), session_cookie="")
+    Path(client.cookie_path).write_text("persisted-cookie", encoding="utf-8")
+
+    assert client._load_session_cookie() == "persisted-cookie"
+
+
+def test_resolve_session_cookie_from_cookie_export(tmp_path):
+    client = ChatGptClient(str(tmp_path), session_cookie="")
+
+    cookie = client._resolve_session_cookie_from_login_content(
+        '[{"name":"__Secure-next-auth.session-token","value":"cookie-123","domain":"chatgpt.com"}]'
+    )
+
+    assert cookie == "cookie-123"
+
+
 @pytest.mark.asyncio
 async def test_ask_does_not_select_workspace_when_workspace_name_is_empty(tmp_path, monkeypatch):
     client = ChatGptClient(str(tmp_path), session_cookie="cookie", workspace_name="")

--- a/tests/unit/client/test_deepseek_client.py
+++ b/tests/unit/client/test_deepseek_client.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from polychat.client.deepseek_client import DeepseekClient
 
 
@@ -35,3 +37,18 @@ def test_extract_assistant_message_prefers_finished_response_fragment():
 
     assert message == "final answer"
     assert done is True
+
+
+def test_load_user_token_json_reads_persisted_file(tmp_path):
+    client = DeepseekClient(str(tmp_path), user_token_json="")
+    Path(client.user_token_path).write_text('{"token":"abc"}', encoding="utf-8")
+
+    assert client._load_user_token_json() == '{"token": "abc"}'
+
+
+def test_resolve_user_token_json_from_json_payload(tmp_path):
+    client = DeepseekClient(str(tmp_path), user_token_json="")
+
+    token_json = client._resolve_user_token_json_from_login_content('{"token":"abc"}')
+
+    assert token_json == '{"token": "abc"}'

--- a/tests/unit/client/test_gemini_client.py
+++ b/tests/unit/client/test_gemini_client.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from polychat.client.gemini_client import GeminiClient
 
 
@@ -10,3 +12,23 @@ def test_extract_response_container_id():
     payload = '[["wrb.fr","hNvQHb","[[[[\"c_e0ccb7f20d4d6c53\",\"r_a1a70693a88a0106\"]'  # noqa: E501
     extracted = GeminiClient._extract_response_container_id(payload, "e0ccb7f20d4d6c53")
     assert extracted == "r_a1a70693a88a0106"
+
+
+def test_load_session_cookies_reads_persisted_file(tmp_path):
+    client = GeminiClient(str(tmp_path), cookie_1psid="", cookie_1psidts="")
+    Path(client.cookies_path).write_text(
+        '{"__Secure-1PSID":"psid","__Secure-1PSIDTS":"psidts"}',
+        encoding="utf-8",
+    )
+
+    assert client._load_session_cookies() == ("psid", "psidts")
+
+
+def test_resolve_session_cookies_from_cookie_export(tmp_path):
+    client = GeminiClient(str(tmp_path), cookie_1psid="", cookie_1psidts="")
+
+    cookies = client._resolve_session_cookies_from_login_content(
+        '[{"name":"__Secure-1PSID","value":"psid"},{"name":"__Secure-1PSIDTS","value":"psidts"}]'
+    )
+
+    assert cookies == ("psid", "psidts")

--- a/tests/unit/client/test_kimi_client.py
+++ b/tests/unit/client/test_kimi_client.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from polychat.client.kimi_client import KimiClient
@@ -14,6 +16,23 @@ def test_load_auth_token_raises_when_missing(tmp_path):
 
     with pytest.raises(ValueError, match="KIMI_AUTH_TOKEN"):
         client._load_auth_token()
+
+
+def test_load_auth_token_reads_persisted_file(tmp_path):
+    client = KimiClient(str(tmp_path), auth_token="")
+    Path(client.auth_token_path).write_text("persisted-kimi", encoding="utf-8")
+
+    assert client._load_auth_token() == "persisted-kimi"
+
+
+def test_resolve_auth_token_from_cookie_export(tmp_path):
+    client = KimiClient(str(tmp_path), auth_token="")
+
+    auth_token = client._resolve_auth_token_from_login_content(
+        '[{"name":"kimi-auth","value":"kimi-123","domain":".kimi.com"}]'
+    )
+
+    assert auth_token == "kimi-123"
 
 
 def test_build_auth_cookie_uses_expected_name_and_domain():

--- a/tests/unit/client/test_perplexity_client.py
+++ b/tests/unit/client/test_perplexity_client.py
@@ -128,3 +128,13 @@ async def test_status_returns_unavailable_when_browser_bootstrap_fails(tmp_path,
     assert status["is_available"] is False
     assert status["is_logged_in"] is False
     assert "Status check failed: boom" in status["detail"]
+
+
+def test_resolve_session_cookie_from_cookie_export(tmp_path):
+    client = PerplexityClient(str(tmp_path), session_cookie="")
+
+    cookie = client._resolve_session_cookie_from_login_content(
+        '[{"name":"__Secure-next-auth.session-token","value":"perplexity-123","domain":".perplexity.ai"}]'
+    )
+
+    assert cookie == "perplexity-123"

--- a/tests/unit/client/test_qwen_client.py
+++ b/tests/unit/client/test_qwen_client.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from polychat.client.qwen_client import QwenClient
 from polychat.model.client.qwen_response import QwenResponse
 
@@ -42,3 +44,20 @@ def test_qwen_response_answer_and_done():
     assert response.answer == "Risposta finale"
     assert response.done is True
     assert response.model_name == "qwen3.5-plus"
+
+
+def test_load_session_cookie_reads_persisted_file(tmp_path):
+    client = QwenClient(str(tmp_path), session_cookie="")
+    Path(client.cookie_path).write_text("persisted-qwen", encoding="utf-8")
+
+    assert client._load_session_cookie() == "persisted-qwen"
+
+
+def test_resolve_session_cookie_from_cookie_export(tmp_path):
+    client = QwenClient(str(tmp_path), session_cookie="")
+
+    cookie = client._resolve_session_cookie_from_login_content(
+        '[{"name":"token","value":"qwen-123","domain":"chat.qwen.ai"}]'
+    )
+
+    assert cookie == "qwen-123"

--- a/tests/unit/controller/test_perplexity_chat_controller.py
+++ b/tests/unit/controller/test_perplexity_chat_controller.py
@@ -8,6 +8,9 @@ from polychat.model.service.chat_metadata import ChatMetadata
 
 
 class _FakePerplexityService:
+    def __init__(self):
+        self.login_content = None
+
     async def ask(self, message: str, chat_id: str | None = None, type_input: bool = True) -> Chat:
         return Chat(id="chat-123", message="", metadata=ChatMetadata(provider="perplexity"))
 
@@ -27,6 +30,9 @@ class _FakePerplexityService:
             "is_logged_in": False,
             "detail": "TODO",
         }
+
+    async def login(self, content: str) -> None:
+        self.login_content = content
 
 
 @pytest.mark.asyncio
@@ -57,3 +63,14 @@ async def test_create_chat_and_wait_returns_complete_payload():
     assert response.chat_id == "chat-123"
     assert response.message == "answer"
     assert response.image_url == "https://img.test/x.png"
+
+
+@pytest.mark.asyncio
+async def test_login_delegates_to_service():
+    service = _FakePerplexityService()
+    controller = PerplexityController(service, ChatToApiMapper())
+
+    response = await controller.login(type("Req", (), {"content": "cookie-123"})())
+
+    assert response == {"status": "ok"}
+    assert service.login_content == "cookie-123"


### PR DESCRIPTION
Closes #9

## Summary
- add `POST /<provider>/chats/login` endpoints across all providers
- parse login payloads from JSON cookie exports, Netscape cookie files, or raw bootstrap tokens when applicable
- persist bootstrap auth material under each provider session directory and save browser storage state for reuse
- add tests for payload parsing, persisted credential fallback, and the new login route

## Validation
- `pytest`
- `python -m compileall polychat tests`